### PR TITLE
Improve contenders ranking for organic queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,9 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# VSCode
+.vscode/
+
 # Rope project settings
 .ropeproject
 

--- a/validator/db/migrations/20241019163242_contenders_stats_hotkey_index.sql
+++ b/validator/db/migrations/20241019163242_contenders_stats_hotkey_index.sql
@@ -1,0 +1,6 @@
+-- migrate:up
+CREATE INDEX IF NOT EXISTS idx_contenders_weights_stats_node_hotkey
+ON contenders_weights_stats (node_hotkey);
+
+-- migrate:down
+DROP INDEX IF EXISTS idx_contenders_weights_stats_node_hotkey;

--- a/validator/db/src/sql/contenders.py
+++ b/validator/db/src/sql/contenders.py
@@ -8,8 +8,6 @@ from validator.utils.generic import generic_constants as gcst
 
 logger = get_logger(__name__)
 
-NET_SCORE_WEIGHT = 0.5 # Can be fine-tuned
-
 async def _build_query_to_fetch_contenders(query_type: str = gcst.SYNTHETIC) -> str:
     """
     Builds the SQL query for fetching contenders based on the query type.
@@ -40,8 +38,7 @@ async def _build_query_to_fetch_contenders(query_type: str = gcst.SYNTHETIC) -> 
             WITH ranked_hotkeys AS (
                 SELECT 
                     cws.{dcst.NODE_HOTKEY},
-                    AVG(cws.{dcst.COLUMN_NORMALISED_NET_SCORE}) AS average_net_score,
-                    AVG(cws.{dcst.COLUMN_NORMALISED_PERIOD_SCORE}) AS average_period_score
+                    AVG(cws.{dcst.COLUMN_NORMALISED_NET_SCORE}) AS average_net_score
                 FROM {dcst.CONTENDERS_WEIGHTS_STATS_TABLE} cws
                 WHERE cws.{dcst.TASK} = $1
                 GROUP BY cws.{dcst.NODE_HOTKEY}
@@ -58,8 +55,7 @@ async def _build_query_to_fetch_contenders(query_type: str = gcst.SYNTHETIC) -> 
             AND c.{dcst.CAPACITY} > 0 
             AND n.{dcst.SYMMETRIC_KEY_UUID} IS NOT NULL
             AND rh.average_net_score > 0
-            AND rh.average_period_score > 0
-            ORDER BY ({NET_SCORE_WEIGHT} * rh.average_net_score + (1 - {NET_SCORE_WEIGHT}) * rh.average_period_score) DESC
+            ORDER BY rh.average_net_score DESC
             LIMIT $2
         """
 

--- a/validator/db/src/sql/contenders.py
+++ b/validator/db/src/sql/contenders.py
@@ -55,7 +55,7 @@ async def _build_query_to_fetch_contenders(query_type: str = gcst.SYNTHETIC) -> 
             AND c.{dcst.CAPACITY} > 0 
             AND n.{dcst.SYMMETRIC_KEY_UUID} IS NOT NULL
             AND rh.average_net_score > 0
-            ORDER BY rh.average_net_score DESC
+            ORDER BY rh.average_net_score DESC, c.{dcst.TOTAL_REQUESTS_MADE} ASC
             LIMIT $2
         """
 

--- a/validator/db/src/sql/contenders.py
+++ b/validator/db/src/sql/contenders.py
@@ -15,9 +15,7 @@ async def _build_query_to_fetch_contenders(query_type: str = gcst.SYNTHETIC) -> 
     Builds the SQL query for fetching contenders based on the query type.
 
     Args:
-        task (str): The task to filter contenders.
-        query_type (str): The type of query (e.g., synthetic or regular).
-        top_x (int): The number of top contenders to fetch.
+        query_type (str): The type of query (e.g., synthetic or organic). Defaults to synthetic.
 
     Returns:
         str: The SQL query as a string.
@@ -62,6 +60,7 @@ async def _build_query_to_fetch_contenders(query_type: str = gcst.SYNTHETIC) -> 
             ORDER BY rh.average_score DESC
             LIMIT $2
         """
+
 
 async def insert_contenders(connection: Connection, contenders: list[Contender], validator_hotkey: str) -> None:
     logger.debug(f"Inserting {len(contenders)} contender records")

--- a/validator/db/src/sql/contenders.py
+++ b/validator/db/src/sql/contenders.py
@@ -123,7 +123,7 @@ async def get_contenders_for_task(connection: Connection, task: str, query_type:
     else:
         # Fetch twice as many hotkeys as we need, to avoid making another query
         top_hotkeys = await _get_top_hotkeys_for_task(connection, task, 2 * top_x)
-        filter_clause = f"AND c.{dcst.NODE_HOTKEY} IN ({', '.join(top_hotkeys)})" if top_hotkeys else ""
+        filter_clause = f"AND c.{dcst.NODE_HOTKEY} IN ({', '.join(top_hotkeys)}) " if top_hotkeys else ""
         filter_clause += f"ORDER BY c.{dcst.TOTAL_REQUESTS_MADE} ASC"
 
     rows = await connection.fetch(

--- a/validator/query_node/src/process_queries.py
+++ b/validator/query_node/src/process_queries.py
@@ -141,7 +141,7 @@ async def process_task(config: Config, message: rdc.QueryQueueMessage):
     stream = task_config.is_stream
 
     async with await config.psql_db.connection() as connection:
-        contenders_to_query = await get_contenders_for_task(connection, task)
+        contenders_to_query = await get_contenders_for_task(connection, task, message.query_type)
 
     if contenders_to_query is None:
         raise ValueError("No contenders to query! :(")


### PR DESCRIPTION
### Overview

Resolves: #70

'seasoning'

The main goal of this pull request is to improve nineteen's organic selection of contenders. Here's a list of the main changes:
- Optimized ranking criterion for miners in organic queries
- Adding a new database index for efficient and scalable ranking calculations

### Key Changes

1. **Updated Ranking Criterion for Contenders**:
This change introduced the `_build_query_to_fetch_contenders` function in [contenders.py](validator/db/src/sql/contenders.py) to dynamically adjust the ranking of contenders based on the query type:

    - **Synthetic queries**: As before, contenders are ordered by `total_requests_made` in ascending order to ensure miners are tested homogeneously.
    - **Organic queries**: Contenders are ranked by the average of their `normalised_net_score`. Previous scores are identified by the miner's hotkey and filtered by task.     

    This change ensures that miners with a good and reliable performance history are given priority, while still allowing synthetic queries to collect comprehensive performance data for each miner.

2. **SQL Migration for Updated Index**:
The other major change is the inclusion of a new index on the `node_hotkey` column of the `contenders_weights_stats` table, added to reduce latency in the ranking calculations for organic queries. Adding this index allows to improve the performance of the query fetching top contenders and ensure scalability of the query nodes.

### Edge Cases

- **Insufficient historical data**: The new ranking query takes into account cases where a miner does not have any previous score or there are no historical records in the database (e.g., after downtime), in which case we simply fallback to the ranking for synthetic queries. For new miners, being selected for organic queries will be challenging at the beginning, but performing well on synthetic queries will help to catch up.

- **Zero scores**: Miners with an average net score of 0 are automatically filtered out in the selection process for organic queries.

- **Identical scores**: In cases where multiple miners have identical scores, we sort by `total_requests_made` in ascending order to ensure a homogeneous distribution of queries.

- **Integration with existing data**: The new raking system integrate seamlessly with existing data, as it only relies on precomputed scores.

### Benefits

- **Optimized miners selection**: The new ranking system ensures that the best contenders are selected for organic queries, while still allowing synthetic queries to collect comprehensive performance data for each miner. This makes nineteen closer to its goal of providing a stable inference product.

- **Improved scalability**: The new index, along with the fact that miners are fetched with a single query, makes the query nodes more scalable for higher traffic.

### Further Improvements

- Right now, historical scores are weighted equally when ranking miners. The only penalty introduced is the deletion of scores older than a week. We might want to introduce a time decaying factor to the scores, so that latest scores are weighted more heavily.

- Instead of excluding miners with a net score of 0, we might want to set a more realistic threshold above which miners are selected.