### PR TITLE
Improve contenders ranking by prioritising them based on historical scores

### DIFF
--- a/validator/db/src/sql/weights.py
+++ b/validator/db/src/sql/weights.py
@@ -96,33 +96,3 @@ async def delete_miner_weights_older_than(connection: Connection, timestamp: dat
         """,
         timestamp
     )
-
-async def get_latest_scoring_stats_for_contenders(
-        connection: Connection, task: str, contenders: list[Contender]
-) -> list[ContenderWeightsInfoPostObject]:
-    rows = await connection.fetch(
-        f"""
-        SELECT
-            {dcst.VERSION_KEY},
-            {dcst.NETUID},
-            {dcst.VALIDATOR_HOTKEY},
-            {dcst.CREATED_AT},
-            {dcst.COLUMN_MINER_HOTKEY},
-            {dcst.COLUMN_TASK},
-            {dcst.COLUMN_AVERAGE_QUALITY_SCORE},
-            {dcst.COLUMN_METRIC_BONUS},
-            {dcst.COLUMN_COMBINED_QUALITY_SCORE},
-            {dcst.COLUMN_PERIOD_SCORE_MULTIPLIER},
-            {dcst.COLUMN_NORMALISED_PERIOD_SCORE},
-            {dcst.COLUMN_CONTENDER_CAPACITY},
-            {dcst.COLUMN_NORMALISED_NET_SCORE}
-        FROM {dcst.CONTENDERS_WEIGHTS_STATS_TABLE}
-        WHERE {dcst.CREATED_AT} = (SELECT MAX({dcst.CREATED_AT}) FROM {dcst.CONTENDERS_WEIGHTS_STATS_TABLE})
-        AND {dcst.COLUMN_TASK} = $1
-        AND {dcst.COLUMN_MINER_HOTKEY} in $2
-        """,
-        task,
-        [contender.node_hotkey for contender in contenders],
-    )
-
-    return [ContenderWeightsInfoPostObject(**row) for row in rows]

--- a/validator/query_node/src/process_queries.py
+++ b/validator/query_node/src/process_queries.py
@@ -1,7 +1,9 @@
 import json
 import time
+from asyncpg import Connection
 from redis.asyncio import Redis
 from core.models.payload_models import ImageResponse
+from validator.db.src.sql.weights import get_latest_scoring_stats_for_contenders
 from validator.models import Contender
 from validator.query_node.src.query_config import Config
 from core import task_config as tcfg
@@ -18,6 +20,7 @@ from validator.utils.generic import generic_constants as gcst
 logger = get_logger(__name__)
 
 MAX_CONCURRENT_TASKS = 10
+CONTENDERS_PER_TASK = 5
 
 
 async def _decrement_requests_remaining(redis_db: Redis, task: str):
@@ -141,7 +144,11 @@ async def process_task(config: Config, message: rdc.QueryQueueMessage):
     stream = task_config.is_stream
 
     async with await config.psql_db.connection() as connection:
-        contenders_to_query = await get_contenders_for_task(connection, task)
+        contenders_for_task = await get_contenders_for_task(connection, task, top_x=CONTENDERS_PER_TASK * 2)
+        if message.query_type == gcst.ORGANIC:
+            contenders_to_query = await _prioritise_contenders_by_scoring_stats(connection, task, contenders_for_task)
+        else:
+            contenders_to_query = contenders_for_task[:CONTENDERS_PER_TASK]
 
     if contenders_to_query is None:
         raise ValueError("No contenders to query! :(")
@@ -160,3 +167,30 @@ async def process_task(config: Config, message: rdc.QueryQueueMessage):
             status_code=500,
             error_message=f"Error processing task {task}: {e}",
         )
+
+
+async def _prioritise_contenders_by_scoring_stats(
+        connection: Connection, task: str, contenders: list[Contender], top_x: int = CONTENDERS_PER_TASK
+)-> list[Contender]:
+    scoring_stats = await get_latest_scoring_stats_for_contenders(connection, task, contenders)
+    scoring_stats_by_contender = {ss.miner_hotkey: ss for ss in scoring_stats}
+    contenders_with_combined_scores = []
+
+    for contender in contenders:
+        contender_scoring_stats = scoring_stats_by_contender.get(contender.node_hotkey)
+        contender_scoring_stats_score = contender_scoring_stats.normalised_net_score if contender_scoring_stats else 0
+        combined_score = await _combine_current_score_with_scoring_stats(
+            contender.total_requests_made, contender_scoring_stats_score
+        )
+        contenders_with_combined_scores.append((contender, combined_score))
+
+    sorted_contenders_with_combined_scores = sorted(contenders_with_combined_scores, key=lambda tup: tup[1], reverse=True)
+
+    return [sc[0] for sc in sorted_contenders_with_combined_scores[:top_x]]
+
+
+async def _combine_current_score_with_scoring_stats(current_score: float, scoring_stats_score: float) -> float:
+    weight_current = 0.6
+    weight_stats = 0.4
+
+    return (current_score * weight_current + scoring_stats_score * weight_stats) / (weight_current + weight_stats)


### PR DESCRIPTION
Resolves #70 

# Overview

This PR tries to improve contenders ranking for organic queries by prioritising contenders who have historically done good. As an assessment of contender's "goodness", the scoring stats from the last cycle are used, which are kept in the local DB.

The solution goes as follows:

First we increase the number of initially selected contenders for a task. (Currently, this number is twice as the previous value, i.e., `top_x` in `get_contenders_for_task()` is increased from 5 to 10. This can be further adapted). Then, we get the latest scoring stats for the initially selected contenders from the DB. Next, we calculate a weighted average of the `NORMALISED_NET_SCORE` from the scoring stats and the contender's `TOTAL_REQUESTS_MADE` as a current score. Finally, we use this value to further filter the initially selected contenders for the task, by selecting those contenders with highest weighted average.

# Goals

The goals of this improvement are threefold:

1) Rank contenders better when distributing organic queries, as it is more likely that a miner that has performed good in the past will perform good in the future.

2) Give further incentive for miners to have good performance for longer period of time in order to increase their chances of being selected.

3) Participate in the "dev seasoning" challenge :)

In addition, prioritising contenders based on their historical scores has been seen as an important dev todo (see [todos.md](https://github.com/namoray/nineteen/blob/production/todos.md) )

# Edge cases

It is possible for a contender not to have scoring stats from the last cycle. In this case, the scoring stats score (`NORMALISED_NET_SCORE`) is explicitly set to 0 so that only the current score (`TOTAL_REQUESTS_MADE`) is taken into account when calculating their weighted average.

# Future improvements

Ideas for future improvements:

* Use scoring stats from more than one cycle, by weighting them in a way that stats from more recent cycles have greater weight.

* Include several scores into the combining equation