### PR TITLE
Weighted sample of quality + period scores composite approach with softmax by Sergiy Pavlyuk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,7 +139,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/validator/db/src/sql/contenders.py
+++ b/validator/db/src/sql/contenders.py
@@ -125,7 +125,7 @@ async def get_contenders_for_selection(connection: Connection, task: str) -> lis
         last_contender_weights_stats AS (
             SELECT * FROM contenders_weights_stats WHERE rank = 1
         )
-        SELECT c.*, s.{dcst.COLUMN_COMBINED_QUALITY_SCORE}
+        SELECT c.*, s.{dcst.COLUMN_COMBINED_QUALITY_SCORE}, s.{dcst.COLUMN_NORMALISED_NET_SCORE}
         FROM contenders c
         LEFT JOIN last_contender_weights_stats s
         -- be as explict as possible with the join conditions

--- a/validator/db/src/sql/contenders.py
+++ b/validator/db/src/sql/contenders.py
@@ -2,7 +2,7 @@ from fiber.logging_utils import get_logger
 
 from asyncpg import Connection
 from validator.db.src.database import PSQLDB
-from validator.models import Contender, PeriodScore, calculate_period_score
+from validator.models import Contender, PeriodScore, calculate_period_score, ContenderSelectionInfo
 from validator.utils.database import database_constants as dcst
 
 logger = get_logger(__name__)
@@ -98,58 +98,42 @@ async def migrate_contenders_to_contender_history(connection: Connection) -> Non
     await connection.execute(f"DELETE FROM {dcst.CONTENDERS_TABLE}")
 
 
-async def get_contenders_for_task(connection: Connection, task: str, top_x: int = 5) -> list[Contender]:
+async def get_contenders_for_selection(connection: Connection, task: str) -> list[ContenderSelectionInfo]:
     rows = await connection.fetch(
         f"""
-        WITH ranked_contenders AS (
+        WITH contenders AS (
             SELECT 
                 c.{dcst.CONTENDER_ID}, c.{dcst.NODE_HOTKEY}, c.{dcst.NODE_ID}, c.{dcst.TASK},
                 c.{dcst.RAW_CAPACITY}, c.{dcst.CAPACITY_TO_SCORE}, c.{dcst.CONSUMED_CAPACITY},
                 c.{dcst.TOTAL_REQUESTS_MADE}, c.{dcst.REQUESTS_429}, c.{dcst.REQUESTS_500}, 
-                c.{dcst.CAPACITY}, c.{dcst.PERIOD_SCORE}, c.{dcst.NETUID},
-                ROW_NUMBER() OVER (
-                    ORDER BY c.{dcst.TOTAL_REQUESTS_MADE} ASC
-                ) AS rank
+                c.{dcst.CAPACITY}, c.{dcst.PERIOD_SCORE}, c.{dcst.NETUID}, c.{dcst.VALIDATOR_HOTKEY}
             FROM {dcst.CONTENDERS_TABLE} c
             JOIN {dcst.NODES_TABLE} n ON c.{dcst.NODE_ID} = n.{dcst.NODE_ID} AND c.{dcst.NETUID} = n.{dcst.NETUID}
             WHERE c.{dcst.TASK} = $1 
             AND c.{dcst.CAPACITY} > 0 
             AND n.{dcst.SYMMETRIC_KEY_UUID} IS NOT NULL
+        ),
+        contenders_weights_stats AS (
+            SELECT {dcst.NETUID}, {dcst.TASK}, {dcst.NODE_HOTKEY}, {dcst.VALIDATOR_HOTKEY}, {dcst.COLUMN_COMBINED_QUALITY_SCORE},
+            ROW_NUMBER() OVER (
+                        PARTITION BY {dcst.NETUID}, {dcst.TASK}, {dcst.NODE_HOTKEY}, {dcst.VALIDATOR_HOTKEY}
+                        ORDER BY {dcst.CREATED_AT} DESC
+                        ) AS rank
+            FROM {dcst.CONTENDERS_WEIGHTS_STATS_TABLE}
+        ),
+        last_contender_weights_stats AS (
+            SELECT * FROM contenders_weights_stats WHERE rank = 1
         )
-        SELECT *
-        FROM ranked_contenders
-        WHERE rank <= $2
-        ORDER BY rank
+        SELECT c.*, s.{dcst.COLUMN_COMBINED_QUALITY_SCORE}
+        FROM contenders c
+        LEFT JOIN last_contender_weights_stats s
+        -- be as explict as possible with the join conditions
+        ON c.{dcst.NETUID} = s.{dcst.NETUID} AND c.{dcst.TASK} = s.{dcst.TASK} 
+        AND c.{dcst.NODE_HOTKEY} = s.{dcst.NODE_HOTKEY} AND c.{dcst.VALIDATOR_HOTKEY} = s.{dcst.VALIDATOR_HOTKEY}
         """,
         task,
-        top_x,
     )
-
-    # If not enough rows are returned, run another query to get more contenders
-    if not rows or len(rows) < top_x:
-        additional_rows = await connection.fetch(
-            f"""
-            SELECT 
-                c.{dcst.CONTENDER_ID}, c.{dcst.NODE_HOTKEY}, c.{dcst.NODE_ID}, c.{dcst.TASK},
-                c.{dcst.RAW_CAPACITY}, c.{dcst.CAPACITY_TO_SCORE}, c.{dcst.CONSUMED_CAPACITY},
-                c.{dcst.TOTAL_REQUESTS_MADE}, c.{dcst.REQUESTS_429}, c.{dcst.REQUESTS_500}, 
-                c.{dcst.CAPACITY}, c.{dcst.PERIOD_SCORE}, c.{dcst.NETUID}
-            FROM {dcst.CONTENDERS_TABLE} c
-            JOIN {dcst.NODES_TABLE} n ON c.{dcst.NODE_ID} = n.{dcst.NODE_ID} AND c.{dcst.NETUID} = n.{dcst.NETUID}
-            WHERE c.{dcst.TASK} = $1 
-            AND c.{dcst.CAPACITY} > 0 
-            AND n.{dcst.SYMMETRIC_KEY_UUID} IS NOT NULL
-            ORDER BY c.{dcst.TOTAL_REQUESTS_MADE} ASC
-            LIMIT $2
-            OFFSET $3
-            """,
-            task,
-            top_x - len(rows) if rows else top_x,
-            len(rows) if rows else 0,
-        )
-        rows = rows + additional_rows if rows else additional_rows
-
-    return [Contender(**row) for row in rows]
+    return [ContenderSelectionInfo(**row) for row in rows]
 
 
 async def update_contender_capacities(psql_db: PSQLDB, contender: Contender, capacitity_consumed: float) -> None:
@@ -312,3 +296,38 @@ async def get_and_decrement_synthetic_request_count(connection: Connection, cont
         return result[dcst.SYNTHETIC_REQUESTS_STILL_TO_MAKE]
     else:
         return None
+
+if __name__ == "__main__":
+    print(
+        f"""
+            WITH contenders AS (
+                SELECT 
+                    c.{dcst.CONTENDER_ID}, c.{dcst.NODE_HOTKEY}, c.{dcst.NODE_ID}, c.{dcst.TASK},
+                    c.{dcst.RAW_CAPACITY}, c.{dcst.CAPACITY_TO_SCORE}, c.{dcst.CONSUMED_CAPACITY},
+                    c.{dcst.TOTAL_REQUESTS_MADE}, c.{dcst.REQUESTS_429}, c.{dcst.REQUESTS_500}, 
+                    c.{dcst.CAPACITY}, c.{dcst.PERIOD_SCORE}, c.{dcst.NETUID}, c.{dcst.VALIDATOR_HOTKEY}
+                FROM {dcst.CONTENDERS_TABLE} c
+                JOIN {dcst.NODES_TABLE} n ON c.{dcst.NODE_ID} = n.{dcst.NODE_ID} AND c.{dcst.NETUID} = n.{dcst.NETUID}
+                WHERE c.{dcst.TASK} = $1 
+                AND c.{dcst.CAPACITY} > 0 
+                AND n.{dcst.SYMMETRIC_KEY_UUID} IS NOT NULL
+            ),
+            contenders_weights_stats AS (
+                SELECT {dcst.NETUID}, {dcst.TASK}, {dcst.NODE_HOTKEY}, {dcst.VALIDATOR_HOTKEY}, {dcst.COLUMN_COMBINED_QUALITY_SCORE},
+                ROW_NUMBER() OVER (
+                            PARTITION BY {dcst.NETUID}, {dcst.TASK}, {dcst.NODE_HOTKEY}, {dcst.VALIDATOR_HOTKEY}
+                            ORDER BY {dcst.CREATED_AT} DESC
+                            ) AS rank
+                FROM {dcst.CONTENDERS_WEIGHTS_STATS_TABLE}
+            ),
+            last_contender_weights_stats AS (
+                SELECT * FROM contenders_weights_stats WHERE rank = 1
+            )
+            SELECT c.*, s.{dcst.COLUMN_COMBINED_QUALITY_SCORE}
+            FROM contenders c
+            LEFT JOIN last_contender_weights_stats s
+            -- be as explict as possible with the join conditions
+            ON c.{dcst.NETUID} = s.{dcst.NETUID} AND c.{dcst.TASK} = s.{dcst.TASK} 
+            AND c.{dcst.NODE_HOTKEY} = s.{dcst.NODE_HOTKEY} AND c.{dcst.VALIDATOR_HOTKEY} = s.{dcst.VALIDATOR_HOTKEY}
+            """
+    )

--- a/validator/db/src/sql/contenders.py
+++ b/validator/db/src/sql/contenders.py
@@ -114,7 +114,8 @@ async def get_contenders_for_selection(connection: Connection, task: str) -> lis
             AND n.{dcst.SYMMETRIC_KEY_UUID} IS NOT NULL
         ),
         contenders_weights_stats AS (
-            SELECT {dcst.NETUID}, {dcst.TASK}, {dcst.NODE_HOTKEY}, {dcst.VALIDATOR_HOTKEY}, {dcst.COLUMN_COMBINED_QUALITY_SCORE},
+            SELECT {dcst.NETUID}, {dcst.TASK}, {dcst.NODE_HOTKEY}, {dcst.VALIDATOR_HOTKEY}, 
+            {dcst.COLUMN_COMBINED_QUALITY_SCORE}, {dcst.COLUMN_NORMALISED_NET_SCORE}
             ROW_NUMBER() OVER (
                         PARTITION BY {dcst.NETUID}, {dcst.TASK}, {dcst.NODE_HOTKEY}, {dcst.VALIDATOR_HOTKEY}
                         ORDER BY {dcst.CREATED_AT} DESC

--- a/validator/models.py
+++ b/validator/models.py
@@ -35,6 +35,24 @@ class Contender(BaseModel):
         contender_id = self.node_hotkey + "-" + self.task
         return contender_id
 
+class ContenderSelectionInfo(Contender):
+    last_combined_quality_score: Optional[float] = None
+
+    def to_contender_model(self) -> Contender:
+        return Contender(
+            node_hotkey=self.node_hotkey,
+            node_id=self.node_id,
+            netuid=self.netuid,
+            task=self.task,
+            raw_capacity=self.raw_capacity,
+            capacity=self.capacity,
+            capacity_to_score=self.capacity_to_score,
+            consumed_capacity=self.consumed_capacity,
+            total_requests_made=self.total_requests_made,
+            requests_429=self.requests_429,
+            requests_500=self.requests_500,
+            period_score=self.period_score,
+        )
 
 def calculate_period_score(
     total_requests_made: float, capacity: float, consumed_capacity: float, requests_429: float, requests_500: float

--- a/validator/models.py
+++ b/validator/models.py
@@ -37,6 +37,7 @@ class Contender(BaseModel):
 
 class ContenderSelectionInfo(Contender):
     last_combined_quality_score: Optional[float] = None
+    normalised_net_score: Optional[float] = None
 
     def to_contender_model(self) -> Contender:
         return Contender(

--- a/validator/query_node/src/process_queries.py
+++ b/validator/query_node/src/process_queries.py
@@ -2,6 +2,7 @@ import json
 import time
 from redis.asyncio import Redis
 from core.models.payload_models import ImageResponse
+from validator.query_node.src.select_contenders import select_contenders
 from validator.models import Contender
 from validator.query_node.src.query_config import Config
 from core import task_config as tcfg
@@ -11,7 +12,6 @@ from validator.utils.redis import redis_constants as rcst
 from fiber.logging_utils import get_logger
 from validator.utils.redis import redis_dataclasses as rdc
 from validator.query_node.src.query import nonstream, streaming
-from validator.db.src.sql.contenders import get_contenders_for_task
 from validator.db.src.sql.nodes import get_node
 from validator.utils.generic import generic_constants as gcst
 
@@ -141,7 +141,7 @@ async def process_task(config: Config, message: rdc.QueryQueueMessage):
     stream = task_config.is_stream
 
     async with await config.psql_db.connection() as connection:
-        contenders_to_query = await get_contenders_for_task(connection, task)
+        contenders_to_query = await select_contenders(connection, task)
 
     if contenders_to_query is None:
         raise ValueError("No contenders to query! :(")

--- a/validator/query_node/src/process_queries.py
+++ b/validator/query_node/src/process_queries.py
@@ -141,7 +141,7 @@ async def process_task(config: Config, message: rdc.QueryQueueMessage):
     stream = task_config.is_stream
 
     async with await config.psql_db.connection() as connection:
-        contenders_to_query = await select_contenders(connection, task)
+        contenders_to_query = await select_contenders(connection, task, message.query_type)
 
     if contenders_to_query is None:
         raise ValueError("No contenders to query! :(")

--- a/validator/query_node/src/select_contenders.py
+++ b/validator/query_node/src/select_contenders.py
@@ -1,0 +1,79 @@
+import math
+import random
+from typing import Optional
+
+from asyncpg import Connection
+
+from validator.db.src.sql.contenders import get_contenders_for_selection
+from validator.models import Contender, ContenderSelectionInfo
+
+WEIGHT_QUALITY_SCORE=2.0
+WEIGHT_PERIOD_SCORE=1.0
+SOFTMAX_TEMPERATURE=1.5
+
+
+def weighted_random_sample_without_replacement(contenders: list[ContenderSelectionInfo], probabilities: list[float], k: int) -> list[ContenderSelectionInfo]:
+    if contenders is None or len(contenders) == 0:
+        return []
+    selected = []
+    for _ in range(k):
+        selected_index = random.choices(range(len(probabilities)), weights=probabilities, k=1)[0]
+        selected.append(contenders[selected_index])
+        del contenders[selected_index]
+        del probabilities[selected_index]
+    return selected
+
+
+def _softmax(scores: list[float], temperature: Optional[float] = None) -> list[float]:
+    """
+    Compute the softmax of scores. Temperature is used to scale the scores
+    so that there is a chance for the lower scores to be selected.
+    It also converts the scores to probabilities that sum to 1
+    """
+    if temperature is None:
+        temperature = SOFTMAX_TEMPERATURE
+
+    if scores is None or len(scores) == 0:
+        return []
+    x = [xi / temperature for xi in scores]
+    max_x = max(x)
+    e_x = [math.exp(xi - max_x) for xi in x]
+    sum_e_x = sum(e_x)
+    return [ei / sum_e_x for ei in e_x]
+
+def _normalize_scores_for_selection(scores: list[float]) -> list[float]:
+    if scores is None or len(scores) == 0:
+        return []
+    max_score = max(scores)
+    min_score = min(scores)
+
+    if max_score == min_score:
+        return [0.0] * len(scores)
+
+    return [(score - min_score) / (max_score - min_score) for score in scores]
+
+
+##########################################################
+async def select_contenders(connection: Connection, task: str, top_x: int = 5) -> list[Contender]:
+    contenders_for_selection = await get_contenders_for_selection(connection, task)
+    if len(contenders_for_selection) <= 1:
+        return [contender.to_contender_model() for contender in contenders_for_selection]
+
+    # extract params
+    last_quality_scores = [0.0 if contender.last_combined_quality_score is None else contender.last_combined_quality_score
+                           for contender in contenders_for_selection]
+    current_period_scores = [0.0 if contender.period_score is None else contender.period_score
+                             for contender in contenders_for_selection]
+
+    # normalize scores
+    normalized_last_quality_scores = _normalize_scores_for_selection(last_quality_scores)
+    normalized_current_period_scores = _normalize_scores_for_selection(current_period_scores)
+
+    composite_scores = [WEIGHT_QUALITY_SCORE * this_quality_score + WEIGHT_PERIOD_SCORE * this_period_score
+                        for this_quality_score, this_period_score
+                        in zip(normalized_last_quality_scores, normalized_current_period_scores)]
+
+    probabilities = _softmax(composite_scores)
+    final_selection = weighted_random_sample_without_replacement(contenders_for_selection, probabilities, top_x)
+
+    return [selected_contender.to_contender_model() for selected_contender in final_selection]

--- a/validator/query_node/src/select_contenders.py
+++ b/validator/query_node/src/select_contenders.py
@@ -68,16 +68,16 @@ async def select_contenders(connection: Connection, task: str, query_type: str, 
     # extract params
     last_quality_scores = [0.0 if contender.last_combined_quality_score is None else contender.last_combined_quality_score
                            for contender in contenders_for_selection]
-    current_period_scores = [0.0 if contender.period_score is None else contender.period_score
+    normalized_period_scores = [0.0 if contender.normalised_net_score is None else contender.normalised_net_score
                              for contender in contenders_for_selection]
 
-    # normalize scores
+    # normalize scores, same scale, from 0 to 1, assume there is enough data
     normalized_last_quality_scores = _normalize_scores_for_selection(last_quality_scores)
-    normalized_current_period_scores = _normalize_scores_for_selection(current_period_scores)
+    normalized_period_scores = _normalize_scores_for_selection(normalized_period_scores)
 
     composite_scores = [WEIGHT_QUALITY_SCORE * this_quality_score + WEIGHT_PERIOD_SCORE * this_period_score
                         for this_quality_score, this_period_score
-                        in zip(normalized_last_quality_scores, normalized_current_period_scores)]
+                        in zip(normalized_last_quality_scores, normalized_period_scores)]
     temperature = SOFTMAX_TEMPERATURE.get(query_type)
     probabilities = _softmax(composite_scores, temperature)
     final_selection = weighted_random_sample_without_replacement(contenders_for_selection, probabilities, top_x)

--- a/validator/query_node/src/select_contenders.py
+++ b/validator/query_node/src/select_contenders.py
@@ -7,8 +7,8 @@ from asyncpg import Connection
 from validator.db.src.sql.contenders import get_contenders_for_selection
 from validator.models import Contender, ContenderSelectionInfo
 
-WEIGHT_QUALITY_SCORE=2.0
-WEIGHT_PERIOD_SCORE=2.0
+WEIGHT_QUALITY_SCORE=1.0
+WEIGHT_PERIOD_SCORE=0.7
 SOFTMAX_TEMPERATURE=2.0
 
 

--- a/validator/query_node/src/select_contenders.py
+++ b/validator/query_node/src/select_contenders.py
@@ -8,8 +8,8 @@ from validator.db.src.sql.contenders import get_contenders_for_selection
 from validator.models import Contender, ContenderSelectionInfo
 
 WEIGHT_QUALITY_SCORE=2.0
-WEIGHT_PERIOD_SCORE=1.0
-SOFTMAX_TEMPERATURE=1.5
+WEIGHT_PERIOD_SCORE=2.0
+SOFTMAX_TEMPERATURE=2.0
 
 
 def weighted_random_sample_without_replacement(contenders: list[ContenderSelectionInfo], probabilities: list[float], k: int) -> list[ContenderSelectionInfo]:

--- a/validator/tests/requirements_test.txt
+++ b/validator/tests/requirements_test.txt
@@ -1,0 +1,2 @@
+pytest==8.3.3
+pytest-asyncio==0.24.0

--- a/validator/tests/test_select_contenders/test_normalize_scores.py
+++ b/validator/tests/test_select_contenders/test_normalize_scores.py
@@ -1,0 +1,13 @@
+import pytest
+from validator.query_node.src.select_contenders import _normalize_scores_for_selection
+
+@pytest.mark.parametrize("scores, expected", [
+    ([1.0, 2.0, 3.0], [0.0, 0.5, 1.0]),
+    ([1.0, 1.0, 1.0], [0.0, 0.0, 0.0]),
+    ([1.0], [0.0]),
+    ([], []),
+    ([-1.0, -2.0, -3.0], [1.0, 0.5, 0.0])
+])
+def test_normalize_scores_for_selection(scores, expected):
+    result = _normalize_scores_for_selection(scores)
+    assert result == expected, f"Expected {expected}, but got {result}"

--- a/validator/tests/test_select_contenders/test_select_contenders.py
+++ b/validator/tests/test_select_contenders/test_select_contenders.py
@@ -23,7 +23,6 @@ dummy_contender_data = {
 @pytest.mark.asyncio
 @patch('validator.query_node.src.select_contenders.WEIGHT_QUALITY_SCORE', 3.0)
 @patch('validator.query_node.src.select_contenders.WEIGHT_PERIOD_SCORE', 2.0)
-@patch('validator.query_node.src.select_contenders.SOFTMAX_TEMPERATURE', 2.0)
 @patch('validator.query_node.src.select_contenders.get_contenders_for_selection', new_callable=AsyncMock)
 async def test_select_contenders(mock_get_contenders_for_selection):
     # Mock data
@@ -37,7 +36,7 @@ async def test_select_contenders(mock_get_contenders_for_selection):
 
     mock_get_contenders_for_selection.return_value = deepcopy(mock_contenders)
 
-    result = await select_contenders(mock_connection, mock_task, top_x=2)
+    result = await select_contenders(mock_connection, mock_task, "default", top_x=2)
 
     assert len(result) == 2
     # order is not guaranteed
@@ -48,7 +47,6 @@ async def test_select_contenders(mock_get_contenders_for_selection):
 @pytest.mark.asyncio
 @patch('validator.query_node.src.select_contenders.WEIGHT_QUALITY_SCORE', 3.0)
 @patch('validator.query_node.src.select_contenders.WEIGHT_PERIOD_SCORE', 2.0)
-@patch('validator.query_node.src.select_contenders.SOFTMAX_TEMPERATURE', 2.0)
 @patch('validator.query_node.src.select_contenders.get_contenders_for_selection', new_callable=AsyncMock)
 async def test_select_contenders(mock_get_contenders_for_selection):
     # Mock data
@@ -58,7 +56,7 @@ async def test_select_contenders(mock_get_contenders_for_selection):
 
     mock_get_contenders_for_selection.return_value = deepcopy(mock_contenders)
 
-    result = await select_contenders(mock_connection, mock_task, top_x=2)
+    result = await select_contenders(mock_connection, mock_task, "default",top_x=2)
 
     assert len(result) == 0
 

--- a/validator/tests/test_select_contenders/test_select_contenders.py
+++ b/validator/tests/test_select_contenders/test_select_contenders.py
@@ -39,14 +39,28 @@ async def test_select_contenders(mock_get_contenders_for_selection):
 
     result = await select_contenders(mock_connection, mock_task, top_x=2)
 
-    print("result", result)
-    # Assertions
     assert len(result) == 2
-
     # order is not guaranteed
     # sort before asserting equality
     assert sorted(result, key=lambda x: x.period_score) == [mock_contenders[0].to_contender_model(), mock_contenders[2].to_contender_model()]
 
+
+@pytest.mark.asyncio
+@patch('validator.query_node.src.select_contenders.WEIGHT_QUALITY_SCORE', 3.0)
+@patch('validator.query_node.src.select_contenders.WEIGHT_PERIOD_SCORE', 2.0)
+@patch('validator.query_node.src.select_contenders.SOFTMAX_TEMPERATURE', 2.0)
+@patch('validator.query_node.src.select_contenders.get_contenders_for_selection', new_callable=AsyncMock)
+async def test_select_contenders(mock_get_contenders_for_selection):
+    # Mock data
+    mock_connection = AsyncMock()
+    mock_task = "test_task"
+    mock_contenders = []
+
+    mock_get_contenders_for_selection.return_value = deepcopy(mock_contenders)
+
+    result = await select_contenders(mock_connection, mock_task, top_x=2)
+
+    assert len(result) == 0
 
 
 def test_random_choice():

--- a/validator/tests/test_select_contenders/test_select_contenders.py
+++ b/validator/tests/test_select_contenders/test_select_contenders.py
@@ -1,0 +1,64 @@
+from copy import deepcopy
+import random
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from numpy.random import choice
+
+from validator.query_node.src.select_contenders import select_contenders
+from validator.models import ContenderSelectionInfo
+
+
+dummy_contender_data = {
+    "node_hotkey": "default_hotkey",
+    "node_id": 0,
+    "netuid": 0,
+    "task": "default_task",
+    "raw_capacity": 0.0,
+    "capacity": 0.0,
+    "capacity_to_score": 0.0
+}
+
+@pytest.mark.asyncio
+@patch('validator.query_node.src.select_contenders.WEIGHT_QUALITY_SCORE', 3.0)
+@patch('validator.query_node.src.select_contenders.WEIGHT_PERIOD_SCORE', 2.0)
+@patch('validator.query_node.src.select_contenders.SOFTMAX_TEMPERATURE', 2.0)
+@patch('validator.query_node.src.select_contenders.get_contenders_for_selection', new_callable=AsyncMock)
+async def test_select_contenders(mock_get_contenders_for_selection):
+    # Mock data
+    mock_connection = AsyncMock()
+    mock_task = "test_task"
+    mock_contenders = [
+        ContenderSelectionInfo(**dummy_contender_data, last_combined_quality_score=2.0, period_score=1.0),
+        ContenderSelectionInfo(**dummy_contender_data, last_combined_quality_score=1.0, period_score=2.0),
+        ContenderSelectionInfo(**dummy_contender_data, last_combined_quality_score=3.0, period_score=3.0)
+    ]
+
+    mock_get_contenders_for_selection.return_value = deepcopy(mock_contenders)
+
+    result = await select_contenders(mock_connection, mock_task, top_x=2)
+
+    print("result", result)
+    # Assertions
+    assert len(result) == 2
+
+    # order is not guaranteed
+    # sort before asserting equality
+    assert sorted(result, key=lambda x: x.period_score) == [mock_contenders[0].to_contender_model(), mock_contenders[2].to_contender_model()]
+
+
+
+def test_random_choice():
+    """ tests that random.choice returns non zero probabilities of bottom contenders"""
+    probabilities = [0.1, 0.2, 0.3, 0.4]
+
+    found = 0
+    # 1000 samples
+    for _ in range(1000):
+        selected_index = random.choices(range(len(probabilities)), weights=probabilities, k=1)[0]
+        if selected_index == 0:
+            found += 1
+    assert found > 0
+    # assert it is less than 10% of the time + margin)
+    assert found < 1000 * (0.1 + 0.05)

--- a/validator/tests/test_select_contenders/test_softmax.py
+++ b/validator/tests/test_select_contenders/test_softmax.py
@@ -1,0 +1,17 @@
+import pytest
+import math
+from validator.query_node.src.select_contenders import _softmax
+
+@pytest.mark.parametrize("scores, temperature, expected", [
+    ([1.0, 2.0, 3.0], 2.0, [0.1863237, 0.30719589, 0.5064804]),
+    ([1.0, 1.0, 1.0], 0.5, [0.33333333, 0.33333333, 0.33333333]),
+    ([1.0], 1.0, [1.0]),
+    ([], 1.0, []),
+    ([-1.0, -2.0, -3.0], 1.0, [0.66524096, 0.24472847, 0.09003057]),
+    ([1.0, 2.0, 3.0], 2.0, [0.186323, 0.307196, 0.506480]),
+    ([1.0, 1.1, 1.2], 2.0, [0.3168124, 0.3330557, 0.350132]),
+    ([1.0, 1.01, 1.02], 2.0, [0.33166806, 0.333331, 0.335001])
+])
+def test_softmax(scores, temperature, expected):
+    result = _softmax(scores, temperature)
+    assert all(math.isclose(r, e, rel_tol=1e-5) for r, e in zip(result, expected)), f"Expected {expected}, but got {result}"


### PR DESCRIPTION
## Task statement: Improve the selection process for miners, to get the best product possible for the frontend, whilst also making sure we have enough data on each miner to judge them.

Before considering the solutions, let's consider both, validator and miner interests/incentives/constraints.

**Validators:**
- effective use of traffic allocation (consequence of fair use and miner's prioritisation mechanism)
- maximise alignment with consensus (maximise rewards, reputation, etc)
- maintain network fairness: each request should be assigned to a miner randomly, ensuring that all miners have an equal chance of receiving any given request. This is from the docs, but my understanding is that task assignment chance must be greater than 0.0
- collect enough data (through either organic or synthetic queries) to be able to fairly assess miner's for the future

**Miner:**
- maximise incentive (points) per task. Roughly max of "best in the crowd" and/or "doing a job no one else wants to do"
- maintain "reputation": do not get kicked out
- From the prioritisation mechanism white paper: a miner only has to maximise the score at the next scoring period
- miner has a choice to not respond or may not respond (internal server error or too many requests error)

**Both players are interested in maximising score with some constraints in capacity and fairness and more importantly maintaining some randomness.**

### Design requirements:
- scalable
- keep it simple, it is first iteration only)
- edge cases handling

### Proposed implementation
Use weighted sample approach + [softmax](https://en.wikipedia.org/wiki/Softmax_function) (cool feature of this function is the temperature parameter that 'blurs' probabilities and increases non-zero chance of being selected from a random sample). Use available info(average_quality and period_scores) from the last contender records. Quality scores are sticky - so one data point is enough. All contenders start with empty period score in each cycle, thus everyone has the same chances, but things might chance during the cycle. How period score works is explained [here](https://github.com/namoray/nineteen/blob/03b75e5a805505b56123ae31560377dec2ac326b/validator/models.py#L49)

### Not technical explanation
we calculate a composite score based on two parameters for each contender: average_quality_score and current cycle period_score

Composite score is calculated as:

Composite score = WEIGHT_QUALITY_SCORE * normalised average_quality_score + WEIGHT_PERIOD_SCORE * normalised_period_score

where:
- WEIGHT_QUALITY_SCORE (current value 1.0) - weight of average quality score
- WEIGHT_PERIOD_SCORE (current_value 0.7) - weight of current period score

Therefore composite score favours quality score with current settings.

In order to increase chances of low score contender to be selected, we calculate probabilities of selection using softmax function with high temperature. Temperature is set by SOFTMAX_TEMPERATURE (current value 2.0) - smoothing parameter for softmax. Temperature of 2.0 effectively increases the chances of low score contender to be selected for query.

Output of softmax is probability of each contender being selected (sum of probabilites = 1).

We then apply weighted sampling to select top_x contenders (current default value = 5, set in select_contenders function arguments. 

A combination of softmax and weighted sampling ensures that even the lowest score contender has a chance for being selected for query.

### Data requirements
No need for new data and complex feature engineering. Fetch all needed info from the contenders table, augment it with score from stats table. No need for indices as tables are only of len(all contenders), but to be safe return latest from stats table. 

### Benefits of this approach: 
- easy to implement
- does not rely on a lot of historical data
- easy to scale while we watch table sizes
- **easy to explain to business**
### Drawbacks: 
- use of somewhat arbitrary weights and softmax params. But need to look at statistics


## Expected result: somewhat novel and more fair approach to select contenders for query, while ensuring we still collect information from all the contenders.


## Further improvements:
- separate weights and logic for organic and synthetic queries
- consider a cut-off score to limit contenders with bad historical score
all of this however goes against the principle of maintaining network fairness for validator


Some Notes:
- contenders table is updated in the beginning of each cycle and some of the info is set to zero (https://github.com/namoray/nineteen/blob/0a9ebe41b39cc1f8a1787c7670b3305572e3336f/validator/control_node/src/cycle/refresh_contenders.py#L147), some info will have to be queried from historical events...
- if the contender was not selected, he will be pushed with zero values to history - also will work with the model
- I noticed that the source code actually uses non linear transformations instead of weights, I think my approach is more flexible


Fixes: #70 
seasoning?
