### PR TITLE
Psuedocode to calculate a smooth-streaming penalty for Miners

### DIFF
--- a/validator/db/src/sql/contenders.py
+++ b/validator/db/src/sql/contenders.py
@@ -233,6 +233,20 @@ async def update_contender_capacities(psql_db: PSQLDB, contender: Contender, cap
         )
 
 
+async def update_contender_smooth_streaming_penalty(psql_db: PSQLDB, contender: Contender, smooth_streaming_penalty: float) -> None:
+    async with await psql_db.connection() as connection:
+        await connection.execute(
+            f"""
+            UPDATE {dcst.CONTENDERS_TABLE}
+            SET {dcst.SMOOTH_STREAMING_PENALTY} = {dcst.SMOOTH_STREAMING_PENALTY} + $1
+            WHERE {dcst.CONTENDER_ID} = $2
+            """,
+            smooth_streaming_penalty,
+            contender.id,
+        )
+
+
+
 async def update_contender_429_count(psql_db: PSQLDB, contender: Contender) -> None:
     async with await psql_db.connection() as connection:
         await connection.execute(
@@ -322,7 +336,8 @@ async def update_contenders_period_scores(connection: Connection, netuid: int) -
             {dcst.CAPACITY},
             {dcst.CONSUMED_CAPACITY},
             {dcst.REQUESTS_429},
-            {dcst.REQUESTS_500}
+            {dcst.REQUESTS_500},
+            {dcst.SMOOTH_STREAMING_PENALTY}
         FROM {dcst.CONTENDERS_TABLE}
         WHERE {dcst.NETUID} = $1
     """,
@@ -337,6 +352,7 @@ async def update_contenders_period_scores(connection: Connection, netuid: int) -
             float(row[dcst.CONSUMED_CAPACITY]),
             float(row[dcst.REQUESTS_429]),
             float(row[dcst.REQUESTS_500]),
+            float(row[dcst.SMOOTH_STREAMING_PENALTY]),
         )
         if score is not None:
             updates.append((score, row[dcst.CONTENDER_ID]))

--- a/validator/models.py
+++ b/validator/models.py
@@ -72,14 +72,14 @@ def calculate_period_score(
 
     # Since the Smooth Streaming Penalty is the aggregate difference 
     # between the max and min latencies of streaming chunks during all 
-    # the good requests, we need to calculate the average penalty per
-    # good request in order to come up with a punishment factor.
-    smooth_streaming_penalty_per_request = smooth_streaming_penalty / good_requests
+    # the requests, good and bad, we need to calculate the average penalty 
+    # per request in order to come up with a punishment factor.
+    smooth_streaming_penalty_per_request = smooth_streaming_penalty / total_requests_made
 
     # We'll normalize the Smooth Streaming Punishment Factor by using
-    # its inverse if it's not already between 0.0 and 1.0
+    # its inverse if it's not already between 0 and 1
     smooth_streaming_punishment_factor = (
-        1 - (1 / smooth_streaming_penalty_per_request) if smooth_streaming_penalty_per_request > 1.0 and smooth_streaming_penalty_per_request > 0 else smooth_streaming_penalty_per_request 
+        1 - (1 / smooth_streaming_penalty_per_request) if smooth_streaming_penalty_per_request > 0 and smooth_streaming_penalty_per_request < 1 else smooth_streaming_penalty_per_request 
     )
 
     return max(

--- a/validator/models.py
+++ b/validator/models.py
@@ -79,7 +79,7 @@ def calculate_period_score(
     # We'll normalize the Smooth Streaming Punishment Factor by using
     # its inverse if it's not already between 0 and 1
     smooth_streaming_punishment_factor = (
-        1 - (1 / smooth_streaming_penalty_per_request) if smooth_streaming_penalty_per_request > 0 and smooth_streaming_penalty_per_request < 1 else smooth_streaming_penalty_per_request 
+        1 - (1 / smooth_streaming_penalty_per_request) if smooth_streaming_penalty_per_request > 1 else smooth_streaming_penalty_per_request 
     )
 
     return max(

--- a/validator/models.py
+++ b/validator/models.py
@@ -24,6 +24,7 @@ class Contender(BaseModel):
     capacity: float = Field(..., description="Declared volume for the UID")
     capacity_to_score: float = Field(..., description="Volume to score")
     consumed_capacity: float = Field(0, description="Queried volume for the UID")
+    smooth_streaming_penalty: float = Field(0, description="Penalty incurred for not streaming at a uniform pace")
     total_requests_made: int = Field(0, description="Total requests made")
     requests_429: int = Field(0, description="HTTP 429 requests")
     requests_500: int = Field(0, description="HTTP 500 requests")
@@ -37,7 +38,12 @@ class Contender(BaseModel):
 
 
 def calculate_period_score(
-    total_requests_made: float, capacity: float, consumed_capacity: float, requests_429: float, requests_500: float
+    total_requests_made: float, 
+    capacity: float, 
+    consumed_capacity: float, 
+    requests_429: float, 
+    requests_500: float,
+    smooth_streaming_penalty: float,
 ) -> float | None:
     """
     Calculate a period score (not including quality which is scored separately)
@@ -58,12 +64,28 @@ def calculate_period_score(
     percentage_of_volume_unqueried = volume_unqueried / capacity
     percentage_of_429s = requests_429 / total_requests_made
     percentage_of_500s = requests_500 / total_requests_made
-    percentage_of_good_requests = (total_requests_made - requests_429 - requests_500) / total_requests_made
+    good_requests = (total_requests_made - requests_429 - requests_500)
+    percentage_of_good_requests = good_requests / total_requests_made
 
     rate_limit_punishment_factor = percentage_of_429s * percentage_of_volume_unqueried
     server_error_punishment_factor = percentage_of_500s * percentage_of_volume_unqueried
 
-    return max(percentage_of_good_requests * (1 - rate_limit_punishment_factor) * (1 - server_error_punishment_factor), 0)
+    # Since the Smooth Streaming Penalty is the aggregate difference 
+    # between the max and min latencies of streaming chunks during all 
+    # the good requests, we need to calculate the average penalty per
+    # good request in order to come up with a punishment factor.
+    smooth_streaming_penalty_per_request = smooth_streaming_penalty / good_requests
+
+    # We'll normalize the Smooth Streaming Punishment Factor by using
+    # its inverse if it's not already between 0.0 and 1.0
+    smooth_streaming_punishment_factor = (
+        1 - (1 / smooth_streaming_penalty_per_request) if smooth_streaming_penalty_per_request > 1.0 and smooth_streaming_penalty_per_request > 0 else smooth_streaming_penalty_per_request 
+    )
+
+    return max(
+        percentage_of_good_requests * (1 - rate_limit_punishment_factor) * (1 - server_error_punishment_factor) * (1 - smooth_streaming_punishment_factor), 
+        0
+    )
 
 
 class RewardData(BaseModel):

--- a/validator/query_node/src/query/streaming.py
+++ b/validator/query_node/src/query/streaming.py
@@ -117,8 +117,8 @@ async def consume_generator(
         async for text in async_chain(first_chunk, generator):
             time_of_current_chunk = time.time()
             
-            # If this is not the first token, then we'll track
-            # the time elapsed since the last token arrived
+            # If this is not the first chunk, then we'll track
+            # the time elapsed since the last chunk arrived
             if time_of_last_chunk is not None:
                 time_between_chunks.append(time_of_current_chunk - time_of_last_chunk)
 

--- a/validator/query_node/src/query/streaming.py
+++ b/validator/query_node/src/query/streaming.py
@@ -169,7 +169,6 @@ async def consume_generator(
         # at least 3 tokens in order to calculate a change in
         # pace, and so we'll leave the penalty at 0
         if len(time_between_chunks) > 1:
-            avg_latency = sum(time_between_chunks) / len(time_between_chunks)
             max_latency = max(time_between_chunks)
             min_latency = min(time_between_chunks)
 

--- a/validator/query_node/src/query/streaming.py
+++ b/validator/query_node/src/query/streaming.py
@@ -122,7 +122,7 @@ async def consume_generator(
             if time_of_last_chunk is not None:
                 time_between_chunks.append(time_of_current_chunk - time_of_last_chunk)
 
-            time_of_last_token = time_of_current_chunk
+            time_of_last_chunk = time_of_current_chunk
 
             if isinstance(text, bytes):
                 text = text.decode()

--- a/validator/query_node/src/query/streaming.py
+++ b/validator/query_node/src/query/streaming.py
@@ -169,7 +169,10 @@ async def consume_generator(
         # at least 3 tokens in order to calculate a change in
         # pace, and so we'll leave the penalty at 0
         if len(time_between_tokens) > 1:
-            smooth_streaming_penalty = max(time_between_tokens)
+            avg_latency = sum(time_between_tokens) / len(time_between_tokens)
+            max_latency = max(time_between_tokens)
+            min_latency = min(time_between_tokens)
+            smooth_streaming_penalty = (max_latency - avg_latency) + (avg_latency - min_latency)
 
 
         if len(text_jsons) > 0:

--- a/validator/query_node/src/query/streaming.py
+++ b/validator/query_node/src/query/streaming.py
@@ -172,7 +172,12 @@ async def consume_generator(
             avg_latency = sum(time_between_chunks) / len(time_between_chunks)
             max_latency = max(time_between_chunks)
             min_latency = min(time_between_chunks)
-            smooth_streaming_penalty = (max_latency - avg_latency) + (avg_latency - min_latency)
+
+            # In order to penalize a Miner for deviating from its average
+            # latency in either direction, we'll the calculate penalty as: 
+            #   smooth_streaming_penalty = (max_latency - avg_latency) + (avg_latency - min_latency)
+            # Which in turn reduces to:
+            smooth_streaming_penalty = max_latency - min_latency 
 
         # Note: We would add the smooth-streaming penalty by persisting it in Redis 
         # and then sending it along to Miner in a subsequent request as the penalty 

--- a/validator/query_node/src/query/streaming.py
+++ b/validator/query_node/src/query/streaming.py
@@ -115,7 +115,7 @@ async def consume_generator(
             # If this is not the first token, then we'll track
             # the time elapsed since the last token arrived
             if time_of_last_token is not None:
-                time_between_tokens.append(time_of_last_token - time_of_current_token)
+                time_between_tokens.append(time_of_current_token - time_of_last_token)
 
             time_of_last_token = time_of_current_token
 

--- a/validator/query_node/src/utils.py
+++ b/validator/query_node/src/utils.py
@@ -9,6 +9,7 @@ from validator.db.src.sql.contenders import (
     update_contender_429_count,
     update_contender_500_count,
     update_contender_capacities,
+    update_contender_smooth_streaming_penalty,
 )
 
 logger = get_logger(__name__)
@@ -17,6 +18,7 @@ logger = get_logger(__name__)
 async def adjust_contender_from_result(
     config: Config,
     query_result: utility_models.QueryResult,
+    smooth_streaming_penalty: float,
     contender: Contender,
     synthetic_query: bool,
     payload: dict,
@@ -39,6 +41,8 @@ async def adjust_contender_from_result(
         logger.debug(f"Capacity consumed: {capacity_consumed}")
 
         await update_contender_capacities(config.psql_db, contender, capacity_consumed)
+
+        await update_contender_smooth_streaming_penalty(config.psql_db, contender, smooth_streaming_penalty)
 
         await db_functions.potentially_store_result_in_db(
             config.psql_db, query_result, query_result.task, synthetic_query=synthetic_query, payload=payload

--- a/validator/utils/database/database_constants.py
+++ b/validator/utils/database/database_constants.py
@@ -87,6 +87,7 @@ RAW_CAPACITY = "raw_capacity"
 CAPACITY = "capacity"
 CAPACITY_TO_SCORE = "capacity_to_score"
 CONSUMED_CAPACITY = "consumed_capacity"
+SMOOTH_STREAMING_PENALTY = "smooth_streaming_penalty"
 
 TOTAL_REQUESTS_MADE = "total_requests_made"
 REQUESTS_429 = "requests_429"


### PR DESCRIPTION
This PR implements a simple approach to calculating a penalty for Miner nodes if/when the latency in streaming tokens varies.

The general approach is as follows for each streaming response:
1. Keep track of when each chunk of tokens is yielded from the generator
2. For every chunk of tokens after the first, keep track of time in between receiving chunks
3. Once we've exhausted everything in the async chain, we'll calculate the smooth streaming penalty
4. The penalty is the sum of the differences between the max/avg and min/avg latencies so that we are calculating penalties based on relative differences rather than absolute differences


Edge Cases:
1. If there is only a single chunk of tokens in the streaming response, there will be no penalty because everything was streamed in a single chunk
2. If there are only two chunks of tokens in the streaming response, there will be no penalty because we data to arrive in at least three chunks for there to be a variation in the pace