### PR TITLE
hotfixes for downtimes

### DIFF
--- a/validator/db/src/sql/contenders.py
+++ b/validator/db/src/sql/contenders.py
@@ -217,7 +217,10 @@ async def get_contenders_for_task(psql_db: PSQLDB, task: str, top_x: int = 5,
     if query_type == gcst.SYNTHETIC:
         return await get_contenders_for_synthetic_task(psql_db, task, top_x)
     elif query_type == gcst.ORGANIC:
-        return await get_contenders_for_organic_task(psql_db, task, top_x)
+        contenders =  await get_contenders_for_organic_task(psql_db, task, top_x)
+        if len(contenders) < top_x:
+            more_contenders = await get_contenders_for_synthetic_task(psql_db, task, top_x-len(contenders))
+            return contenders+more_contenders
     else:
         raise ValueError(f"No contender selection strategy have been implemented for query type : {query_type}")
 

--- a/validator/db/src/sql/weights.py
+++ b/validator/db/src/sql/weights.py
@@ -2,8 +2,6 @@ from fiber.logging_utils import get_logger
 
 from asyncpg import Connection
 from datetime import datetime
-from validator.db.src.database import PSQLDB
-from validator.models import Contender, PeriodScore, calculate_period_score
 from validator.utils.database import database_constants as dcst
 from validator.utils.post.nineteen import ContenderWeightsInfoPostObject, MinerWeightsPostObject
 
@@ -81,13 +79,19 @@ async def insert_weights(connection: Connection, miner_weights: list[MinerWeight
     )
 
 async def delete_weights_info_older_than(connection: Connection, timestamp: datetime) -> None:
-    await connection.execute(
-        f"""
-        DELETE FROM {dcst.CONTENDERS_WEIGHTS_STATS_TABLE}
-        WHERE {dcst.CREATED_AT} < $1
-        """,
-        timestamp
-    )
+   await connection.execute(
+       f"""
+       WITH latest_records AS (
+           SELECT DISTINCT ON (node_hotkey, task) id
+           FROM {dcst.CONTENDERS_WEIGHTS_STATS_TABLE}
+           ORDER BY node_hotkey, task, created_at DESC
+       )
+       DELETE FROM {dcst.CONTENDERS_WEIGHTS_STATS_TABLE}
+       WHERE created_at < $1
+       AND id NOT IN (SELECT id FROM latest_records)
+       """,
+       timestamp
+   )
 
 
 async def delete_miner_weights_older_than(connection: Connection, timestamp: datetime) -> None:


### PR DESCRIPTION
- keep latest record per contender (hotkey + task) in weights stats table (for organic selection)
- more assured fallback to synth selection logic in case of issues with organic one