### PR TITLE
Remove downtime between cycles

### DIFF
--- a/validator/control_node/src/cycle/execute_cycle.py
+++ b/validator/control_node/src/cycle/execute_cycle.py
@@ -21,6 +21,7 @@ from validator.control_node.src.cycle.schedule_synthetic_queries import schedule
 from validator.db.src.sql.nodes import (
     get_nodes,
 )
+from validator.db.src.sql.nodes import insert_symmetric_keys_for_nodes
 from fiber.logging_utils import get_logger
 
 from validator.models import Contender
@@ -48,20 +49,29 @@ async def _post_vali_stats(config: Config):
 async def get_nodes_and_contenders(config: Config) -> list[Contender] | None:
     logger.info("Starting cycle...")
     if config.refresh_nodes:
-        logger.info("First refreshing metagraph and storing the nodes")
-        nodes = await refresh_nodes.get_and_store_nodes(config)
+        logger.info("First refreshing metagraph and getting nodes")
+        initial_nodes = await refresh_nodes.get_refreashed_nodes(config)
     else:
-        nodes = await get_nodes(config.psql_db, config.netuid)
+        initial_nodes = await get_nodes(config.psql_db, config.netuid)
 
     await _post_vali_stats(config)
 
     logger.info("Got nodes! Performing handshakes now...")
 
-    nodes = await refresh_nodes.perform_handshakes(nodes, config)
+    all_handshake_nodes, nodes_where_handshake_worked = await refresh_nodes.perform_handshakes(initial_nodes, config)
 
     logger.info("Got handshakes! Getting the contenders from the nodes...")
 
-    contenders = await refresh_contenders.get_and_store_contenders(config, nodes)
+    if config.refresh_nodes:
+        logger.info(f"Storing {len(initial_nodes)} nodes...")
+        await refresh_nodes.store_nodes(config, initial_nodes)
+        await refresh_nodes.update_our_validator_node(config)
+
+    async with await config.psql_db.connection() as connection:
+        logger.info(f"Updating symmetric keys for {len(nodes_where_handshake_worked)} nodes...")
+        await insert_symmetric_keys_for_nodes(connection, nodes_where_handshake_worked)
+
+    contenders = await refresh_contenders.get_and_store_contenders(config, all_handshake_nodes)
 
     logger.info(f"Got all contenders! {len(contenders)} contenders will be queried...")
 

--- a/validator/control_node/src/cycle/execute_cycle.py
+++ b/validator/control_node/src/cycle/execute_cycle.py
@@ -50,7 +50,7 @@ async def get_nodes_and_contenders(config: Config) -> list[Contender] | None:
     logger.info("Starting cycle...")
     if config.refresh_nodes:
         logger.info("First refreshing metagraph and getting nodes")
-        initial_nodes = await refresh_nodes.get_refreashed_nodes(config)
+        initial_nodes = await refresh_nodes.get_refreash_nodes(config)
     else:
         initial_nodes = await get_nodes(config.psql_db, config.netuid)
 

--- a/validator/control_node/src/cycle/execute_cycle.py
+++ b/validator/control_node/src/cycle/execute_cycle.py
@@ -50,7 +50,7 @@ async def get_nodes_and_contenders(config: Config) -> list[Contender] | None:
     logger.info("Starting cycle...")
     if config.refresh_nodes:
         logger.info("First refreshing metagraph and getting nodes")
-        initial_nodes = await refresh_nodes.get_refreash_nodes(config)
+        initial_nodes = await refresh_nodes.get_refresh_nodes(config)
     else:
         initial_nodes = await get_nodes(config.psql_db, config.netuid)
 

--- a/validator/control_node/src/cycle/refresh_nodes.py
+++ b/validator/control_node/src/cycle/refresh_nodes.py
@@ -108,7 +108,7 @@ async def _handshake(config: Config, node: Node, async_client: httpx.AsyncClient
     return node_copy
 
 
-async def perform_handshakes(nodes: list[Node], config: Config) -> list[Node]:
+async def perform_handshakes(nodes: list[Node], config: Config) -> tuple:
     tasks = []
     shaked_nodes: list[Node] = []
     for node in nodes:
@@ -129,4 +129,4 @@ async def perform_handshakes(nodes: list[Node], config: Config) -> list[Node]:
         return []
     logger.info(f"✅ performed handshakes successfully with {len(nodes_where_handshake_worked)} nodes!")
 
-    return shaked_nodes
+    return shaked_nodes, nodes_where_handshake_worked

--- a/validator/control_node/src/cycle/refresh_nodes.py
+++ b/validator/control_node/src/cycle/refresh_nodes.py
@@ -26,7 +26,7 @@ def _format_exception(e: Exception) -> str:
     return f"Exception Type: {type(e).__name__}\nException Message: {str(e)}\nTraceback:\n{''.join(traceback.format_tb(e.__traceback__))}"
 
 
-async def get_refreash_nodes(config: Config) -> list[Node]:
+async def get_refresh_nodes(config: Config) -> list[Node]:
     async with await config.psql_db.connection() as connection:
         if await is_recent_update(connection, config.netuid):
             return await get_nodes(config.psql_db, config.netuid)
@@ -126,7 +126,7 @@ async def perform_handshakes(nodes: list[Node], config: Config) -> tuple[list[No
     ]
     if len(nodes_where_handshake_worked) == 0:
         logger.info("❌ Failed to perform handshakes with any nodes!")
-        return []
+        return [], []
     logger.info(f"✅ performed handshakes successfully with {len(nodes_where_handshake_worked)} nodes!")
 
     return shaked_nodes, nodes_where_handshake_worked

--- a/validator/control_node/src/cycle/refresh_nodes.py
+++ b/validator/control_node/src/cycle/refresh_nodes.py
@@ -26,7 +26,7 @@ def _format_exception(e: Exception) -> str:
     return f"Exception Type: {type(e).__name__}\nException Message: {str(e)}\nTraceback:\n{''.join(traceback.format_tb(e.__traceback__))}"
 
 
-async def get_refreashed_nodes(config: Config) -> list[Node]:
+async def get_refreash_nodes(config: Config) -> list[Node]:
     async with await config.psql_db.connection() as connection:
         if await is_recent_update(connection, config.netuid):
             return await get_nodes(config.psql_db, config.netuid)

--- a/validator/control_node/src/cycle/refresh_nodes.py
+++ b/validator/control_node/src/cycle/refresh_nodes.py
@@ -108,7 +108,7 @@ async def _handshake(config: Config, node: Node, async_client: httpx.AsyncClient
     return node_copy
 
 
-async def perform_handshakes(nodes: list[Node], config: Config) -> tuple:
+async def perform_handshakes(nodes: list[Node], config: Config) -> tuple[list[Node], list[Node]]:
     tasks = []
     shaked_nodes: list[Node] = []
     for node in nodes:

--- a/validator/control_node/src/cycle/refresh_nodes.py
+++ b/validator/control_node/src/cycle/refresh_nodes.py
@@ -12,7 +12,7 @@ from validator.db.src.sql.nodes import get_nodes, migrate_nodes_to_history, inse
 from fiber.logging_utils import get_logger
 from fiber.chain import fetch_nodes
 from validator.control_node.src.control_config import Config
-from validator.db.src.sql.nodes import insert_symmetric_keys_for_nodes, update_our_vali_node_in_db
+from validator.db.src.sql.nodes import update_our_vali_node_in_db
 from fiber.validator import handshake, client
 import httpx
 from datetime import datetime, timedelta
@@ -26,7 +26,7 @@ def _format_exception(e: Exception) -> str:
     return f"Exception Type: {type(e).__name__}\nException Message: {str(e)}\nTraceback:\n{''.join(traceback.format_tb(e.__traceback__))}"
 
 
-async def get_and_store_nodes(config: Config) -> list[Node]:
+async def get_refreashed_nodes(config: Config) -> list[Node]:
     async with await config.psql_db.connection() as connection:
         if await is_recent_update(connection, config.netuid):
             return await get_nodes(config.psql_db, config.netuid)
@@ -35,11 +35,6 @@ async def get_and_store_nodes(config: Config) -> list[Node]:
 
     # Ensuring the Nodes get converted to NodesWithFernet
     nodes = [Node(**node.model_dump(mode="json")) for node in raw_nodes]
-
-    await store_nodes(config, nodes)
-    await update_our_validator_node(config)
-
-    logger.info(f"Stored {len(nodes)} nodes.")
     return nodes
 
 
@@ -133,8 +128,5 @@ async def perform_handshakes(nodes: list[Node], config: Config) -> list[Node]:
         logger.info("❌ Failed to perform handshakes with any nodes!")
         return []
     logger.info(f"✅ performed handshakes successfully with {len(nodes_where_handshake_worked)} nodes!")
-
-    async with await config.psql_db.connection() as connection:
-        await insert_symmetric_keys_for_nodes(connection, nodes_where_handshake_worked)
 
     return shaked_nodes


### PR DESCRIPTION
-get refreshed nodes but only save them after handshakes are performed (so that the symmetric keys are valide)